### PR TITLE
Fix disable

### DIFF
--- a/ElvUI_PartyFrameLayout/ElvUI_PartyFrameLayout.lua
+++ b/ElvUI_PartyFrameLayout/ElvUI_PartyFrameLayout.lua
@@ -75,10 +75,17 @@ end
 
 function PFLayout:Update()
     if E.db.ElvUI_PartyFrameLayout.enable then
+        if ElvUF_PartyGroup1 and not self:IsHooked(ElvUF_PartyGroup1, "Update") then
+            self:SecureHook(ElvUF_PartyGroup1, "Update", "ApplyLayout")
+        end
         self:ApplyLayout()
     else
-        if ElvUF_PartyGroup1 and ElvUF_PartyGroup1.Update then
-            ElvUF_PartyGroup1:Update()
+        if ElvUF_PartyGroup1 and self:IsHooked(ElvUF_PartyGroup1, "Update") then
+            self:Unhook(ElvUF_PartyGroup1, "Update")
+        end
+
+        if E.UnitFrames and E.UnitFrames.Update_AllFrames then
+            E.UnitFrames:Update_AllFrames()
         end
     end
 end
@@ -92,7 +99,7 @@ function PFLayout:InsertOptions()
             enable = {
                 order = 1,
                 type = "toggle",
-                name = "Enable Layout Override",
+                name = "Enable",
                 get = function(info) return E.db.ElvUI_PartyFrameLayout.enable end,
                 set = function(info, value)
                     E.db.ElvUI_PartyFrameLayout.enable = value
@@ -102,7 +109,7 @@ function PFLayout:InsertOptions()
             buttonsPerRow = {
                 order = 2,
                 type = "range",
-                name = "Buttons Per Row",
+                name = "Frames Per Row",
                 min = 1, max = 5, step = 1,
                 disabled = function() return not E.db.ElvUI_PartyFrameLayout.enable end,
                 get = function(info) return E.db.ElvUI_PartyFrameLayout.buttonsPerRow end,
@@ -125,7 +132,6 @@ function PFLayout:Initialize()
         end)
     end)
 
-    -- Hook into ElvUI's internal update function for party frames
     if ElvUF_PartyGroup1 and not self:IsHooked(ElvUF_PartyGroup1, "Update") then
         self:SecureHook(ElvUF_PartyGroup1, "Update", "ApplyLayout")
     end

--- a/ElvUI_PartyFrameLayout/ElvUI_PartyFrameLayout.toc
+++ b/ElvUI_PartyFrameLayout/ElvUI_PartyFrameLayout.toc
@@ -1,8 +1,8 @@
 ## Interface: 110105
 ## Author: Roak Static
-## Version: 0.0.2
+## Version: 0.0.3
 ## Title: |cff1784d1ElvUI|r |cffFF5722PartyFrameLayout|r
-## Notes: Adds a grid layout for party frames to ElvUI.
+## Notes: Adds a grid layout for Party Frames to ElvUI.
 ## RequiredDeps: ElvUI
 
 ElvUI_PartyFrameLayout.lua


### PR DESCRIPTION
## Summary

Improves plugin behavior when toggling the layout on/off. Specifically, ensures ElvUI’s default party frame layout is properly restored when the plugin is disabled, preventing Lua errors and preserving user settings.

## Changes

- Implemented a hook/unhook mechanism using `SecureHook()` and `Unhook()`
- When the plug is disbaled, it now reverts to EvlUI defaults: using `E.UnitFrames:Update_AllFrames()` instead of calling `Update()` directly on `ElvUF_PartyGroup1`, which caused frame refence issues.
- Replaced direct layout overrides with `ApplyLayout()` method during active state.
- Bumped `.toc` file verison to reflect changes.

## To Do

- [x] Update TOC

## Related Issue

Closes https://github.com/RoakStatic/ElvUI_PartyFrameLayout/issues/1 - resolves Lua error on plugin disable and ensures consistent layout reversion.